### PR TITLE
Bump CI action versions for compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 permissions:
   contents: write
-  
+
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -23,16 +23,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup MAPI
-        uses: BadMagic100/setup-hk@v1
+        uses: BadMagic100/setup-hk@v2
         with:
           apiPath: API
           dependencyFilePath: ModDependencies.txt
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
 
       - name: Install dependencies
         run: dotnet restore
@@ -41,12 +41,12 @@ jobs:
         run: dotnet build -c Release
 
       - name: Prepare artifacts for release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: GatheringSwarmAlwaysOn
           path: GatheringSwarmAlwaysOn/bin/Publish/GatheringSwarmAlwaysOn/zip
       - name: Upload metadata
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: metadata
           path: GatheringSwarmAlwaysOn/bin/Publish/GatheringSwarmAlwaysOn/metadata
@@ -59,7 +59,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.should_release == 'true'
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Zip
@@ -75,7 +75,7 @@ jobs:
           sed '1s/^\xEF\xBB\xBF//' < artifacts/metadata/version.txt > version.txt
           echo "buildVersion=$(cat version.txt)" >> $GITHUB_OUTPUT
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
           generate_release_notes: false
@@ -83,4 +83,4 @@ jobs:
           tag_name: v${{ steps.details.outputs.buildVersion }}
           body_path: ChangeLog.txt
           files: |
-            GatheringSwarmAlwaysOn.zip 
+            GatheringSwarmAlwaysOn.zip


### PR DESCRIPTION
## Summary
- Bumps all GitHub Actions to their latest major versions to ensure CI continues working (several v3 actions are deprecated)
- `BadMagic100/setup-hk@v1` → `v2` for HK 1.5 API compatibility

## Changes
- `actions/checkout` v3 → v4
- `BadMagic100/setup-hk` v1 → v2
- `actions/setup-dotnet` v3 → v4
- `actions/upload-artifact` v3 → v4
- `actions/download-artifact` v3 → v4
- `softprops/action-gh-release` v1 → v2

## Test plan
- [x] Builds locally with `dotnet build -c Release` (0 warnings, 0 errors)
- [x] Tested in-game on HK 1.5 — mod loads and functions correctly